### PR TITLE
Added documentation of `// @noflow`

### DIFF
--- a/docs/rules/flow-header.md
+++ b/docs/rules/flow-header.md
@@ -29,14 +29,21 @@ var hello = 'world';
 
 ```
 
+If you have individual files where Flow can not be used (such as in an
+Isomorphic React Application with mixed Babel and non Babel code) you can turn
+off flow for that one file with:
+
+```js
+
+// @noflow
+var hello = 'world';
+
+```
+
 ## Automatic fixing
 
 The rule also supports `eslint --fix`. It adds a `// @flow` line to the top
 of files that don't have it already.
-
-## When Not To Use It
-
-This rule is not appropriate when your project has a mix of plain (legacy) js with new flow typed js.
 
 ## Further Reading
 


### PR DESCRIPTION
To save people having to search closed issues for the details of #1, I suggest this update to the Readme.

Our use case is that we have an Isomophic React application using `@babel/register` for JIT compiler. The only file that isn't covered by Babel is our `server.js` with the express code in it. This may be an unusual use case though so happy to get feedback on the suggestion if it's not appropriate.